### PR TITLE
Add description field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# hugo-repro-missing-data
+
+See <https://github.com/gohugoio/hugo/issues/8919>

--- a/config.toml
+++ b/config.toml
@@ -4,25 +4,26 @@ title = 'My New Hugo Site'
 languageCode = "en"
 defaultContentLanguage = "en"
 
+disableKinds = ['taxonomy','term','sitemap']
 
 [languages]
   [languages.en]
-    title = "Repro"
-    languageName = "English"
     contentDir = "content/en"
+    languageName = "English"
+    title = "Repro"
     weight = 1
 
   [languages.zh_CN]
+    contentDir = "content/zh_CN"
+    languageName = "简体中文"
     title = "Repro"
     weight = 2
-    languageName = "简体中文"
-    contentDir = "content/zh_CN"
 
 [outputFormats]
   [outputFormats.metadata]
     baseName = "metadata"
-    mediaType = "text/html"
     isPlainText = true
+    mediaType = "text/html"
     notAlternative = true
 
 [outputs]

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Title (en)
+description: Description (en)
 summary: Summary (en)
 
 menu:

--- a/content/zh_CN/_index.md
+++ b/content/zh_CN/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Title (zh)
+description: Description (zh)
 summary: Summary (zh)
 
 menu:

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -4,7 +4,7 @@
 {{ range .Site.Menus.main }}
   {{ $p := .Page }}
   {{ range $p.Translations}}
-    <li>{{ .Title }}, {{ .Summary }}</li>
+    <li>{{ .Title }}, {{ .Description }}, {{ .Summary }}</li>
   {{ end }}
 {{ end }}
 </ul>

--- a/layouts/home.metadata.html
+++ b/layouts/home.metadata.html
@@ -3,7 +3,7 @@
 {{ range .Site.Menus.main }}
   {{ $p := .Page }}
   {{ range $p.Translations}}
-    <li>{{ .Title }}, {{ .Summary }}</li>
+    <li>{{ .Title }}, {{ .Description }}, {{ .Summary }}</li>
   {{ end }}
 {{ end }}
 </ul>


### PR DESCRIPTION
I suspect that this behavior might be limited to the summary field, due to the unique way this field is handled. See my [recent comments](https://github.com/gohugoio/hugo/issues/8910#issuecomment-9031586000).

This PR adds a description to the frontmatter and templates. No problems.